### PR TITLE
add liger-kernel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,10 @@ tabulate = "^0.9.0"
 orjson = "==3.10.7"
 gradio = "==4.43.0"
 dvc = "==3.53.1"
+liger-kernel = "0.3.0"
 huggingface-hub = "^0.24.6"
 openai = "^1.44.1"
+
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
in the sft.py script on line 88 there is an import of the liger-kernel 

if sft_config.use_liger:
        **from liger_kernel.transformers import apply_liger_kernel_to_llama, apply_liger_kernel_to_mistral**
        apply_liger_kernel_to_llama(
            rope=False,
            swiglu=True,
            cross_entropy=False,
            fused_linear_cross_entropy=True,
            rms_norm=False
        )
        apply_liger_kernel_to_mistral(
            rope=False,
            swiglu=True,
            cross_entropy=False,
            fused_linear_cross_entropy=True,
            rms_norm=False
        )


Lack of the liger-kernel lib causes an error
**ModuleNotFoundError: No module named 'liger_kernel'**